### PR TITLE
Require bold in post formatting

### DIFF
--- a/standup/bot.py
+++ b/standup/bot.py
@@ -52,9 +52,9 @@ async def on_message(msg: discord.Message) -> None:
             "Your posted standup is incorrectly formatted:\n"
             f"```{msg.content}```"
             "Please format your standup correctly, here is a template example: ```\n"
-            "Yesterday I: [...]\n"
-            "Today I will: [...]\n"
-            "Potential hard problems: [...]\n"
+            "\*\*Yesterday I:\*\* [...]\n"
+            "\*\*Today I will:\*\* [...]\n"
+            "\*\*Potential hard problems:\*\* [...]\n"
             "```"
         )
 

--- a/standup/bot.py
+++ b/standup/bot.py
@@ -52,9 +52,9 @@ async def on_message(msg: discord.Message) -> None:
             "Your posted standup is incorrectly formatted:\n"
             f"```{msg.content}```"
             "Please format your standup correctly, here is a template example: ```\n"
-            "\*\*Yesterday I:\*\* [...]\n"
-            "\*\*Today I will:\*\* [...]\n"
-            "\*\*Potential hard problems:\*\* [...]\n"
+            "**Yesterday I:** [...]\n"
+            "**Today I will:** [...]\n"
+            "**Potential hard problems:** [...]\n"
             "```"
         )
 

--- a/standup/post.py
+++ b/standup/post.py
@@ -4,9 +4,9 @@ import re
 
 
 STANDUP_REGEX = (
-    r"^Yesterday I:[\s\S]+\n"
-    r"Today I will:[\s\S]+\n"
-    r"Potential hard problems:[\s\S]+$"
+    r"^\*\*Yesterday I:\*\*[\s\S]+\n"
+    r"\*\*Today I will:\*\*[\s\S]+\n"
+    r"\*\*Potential hard problems:\*\*[\s\S]+$"
 )
 
 

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -3,9 +3,9 @@ from standup.post import message_is_formatted
 
 def test_message_is_formatted_accepts_plain() -> None:
     msg = (
-        "Yesterday I: Did nothing!\n"
-        "Today I will: Work on my discord bot!\n"
-        "Potential hard problems: None!"
+        "**Yesterday I:** Did nothing!\n"
+        "**Today I will:** Work on my discord bot!\n"
+        "**Potential hard problems:** None!"
     )
 
     assert message_is_formatted(msg)
@@ -13,9 +13,9 @@ def test_message_is_formatted_accepts_plain() -> None:
 
 def test_message_is_formatted_fails_improper_newlines() -> None:
     msg = (
-        "Yesterday I: did nothing!"
-        "Today I will: Work on my discord bot!"
-        "Potential hard problems: None!"
+        "**Yesterday I:** did nothing!"
+        "**Today I will:** Work on my discord bot!"
+        "**Potential hard problems:** None!"
     )
 
     assert not message_is_formatted(msg)


### PR DESCRIPTION
Change post formatting to require bold in the post format e.g.
**Yesterday I:** vs Yesterday I:

I wasn't able to test the entire thing, as I don't have Docker at the moment, but I think it should be fine.